### PR TITLE
CautionaryAlertEnded Event

### DIFF
--- a/ActivityListener.Tests/ActivityListener.Tests.csproj
+++ b/ActivityListener.Tests/ActivityListener.Tests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.16.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ActivityListener.Tests/EventTypeHelper.cs
+++ b/ActivityListener.Tests/EventTypeHelper.cs
@@ -28,7 +28,8 @@ namespace ActivityListener.Tests
                 EventTypes.NoteCreatedAgainstProcessEvent,
                 EventTypes.ProcessStartedAgainstTenureEvent,
                 EventTypes.ProcessStartedAgainstPersonEvent,
-                EventTypes.CautionaryAlertCreatedEvent
+                EventTypes.CautionaryAlertCreatedEvent,
+                EventTypes.CautionaryAlertEndedEvent
             };
     }
 }

--- a/ActivityListener.Tests/Factories/EntityFactoryTest.cs
+++ b/ActivityListener.Tests/Factories/EntityFactoryTest.cs
@@ -59,6 +59,9 @@ namespace ActivityListener.Tests.Factories
                 case EventTypes.PersonRemovedFromTenureEvent:
                     eventSns.GetActivityType().Should().Be(ActivityType.delete);
                     break;
+                case EventTypes.CautionaryAlertEndedEvent:
+                    eventSns.GetActivityType().Should().Be(ActivityType.end);
+                    break;
                 default:
                     {
                         Action act = () => eventSns.GetActivityType();
@@ -119,6 +122,7 @@ namespace ActivityListener.Tests.Factories
                     eventSns.GetTargetType().Should().Be(TargetType.process);
                     break;
                 case EventTypes.CautionaryAlertCreatedEvent:
+                case EventTypes.CautionaryAlertEndedEvent:
                     eventSns.GetTargetType().Should().Be(TargetType.cautionaryAlert);
                     break;
                 default:

--- a/ActivityListener/ActivityListener.csproj
+++ b/ActivityListener/ActivityListener.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
-    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.17.0-feat-end-target-0001" />
+    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.17.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ActivityListener/ActivityListener.csproj
+++ b/ActivityListener/ActivityListener.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
-    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.16.0" />
+    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.17.0-feat-end-target-0001" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ActivityListener/EventTypes.cs
+++ b/ActivityListener/EventTypes.cs
@@ -36,5 +36,6 @@ namespace ActivityListener
         public const string ProcessStartedAgainstPersonEvent = "ProcessStartedAgainstPersonEvent";
 
         public const string CautionaryAlertCreatedEvent = "CautionaryAlertCreatedEvent";
+        public const string CautionaryAlertEndedEvent = "CautionaryAlertEndedEvent";
     }
 }

--- a/ActivityListener/Factories/EntityFactory.cs
+++ b/ActivityListener/Factories/EntityFactory.cs
@@ -37,6 +37,8 @@ namespace ActivityListener.Factories
                 case EventTypes.ContactDetailDeletedEvent:
                 case EventTypes.PersonRemovedFromTenureEvent:
                     return ActivityType.delete;
+                case EventTypes.CautionaryAlertEndedEvent:
+                    return ActivityType.end;
 
                 default:
                     throw new ArgumentException($"Unknown event type: {eventSns.EventType}");
@@ -82,6 +84,7 @@ namespace ActivityListener.Factories
                 case EventTypes.ProcessStartedAgainstPersonEvent:
                     return TargetType.person;
                 case EventTypes.CautionaryAlertCreatedEvent:
+                case EventTypes.CautionaryAlertEndedEvent:
                     return TargetType.cautionaryAlert;
 
                 default:


### PR DESCRIPTION
Every time a CautionaryAlert is Ended it should trigger the Activity Listener which would then update the data in the Activity History API. 