### PR TITLE
Handle PatchOrAreaResEntityEditedEvent

### DIFF
--- a/ActivityListener.Tests/EventTypeHelper.cs
+++ b/ActivityListener.Tests/EventTypeHelper.cs
@@ -29,7 +29,8 @@ namespace ActivityListener.Tests
                 EventTypes.ProcessStartedAgainstTenureEvent,
                 EventTypes.ProcessStartedAgainstPersonEvent,
                 EventTypes.CautionaryAlertCreatedEvent,
-                EventTypes.CautionaryAlertEndedEvent
+                EventTypes.CautionaryAlertEndedEvent,
+                EventTypes.PatchOrAreaResEntityEditedEvent
             };
     }
 }

--- a/ActivityListener.Tests/Factories/EntityFactoryTest.cs
+++ b/ActivityListener.Tests/Factories/EntityFactoryTest.cs
@@ -53,6 +53,7 @@ namespace ActivityListener.Tests.Factories
                 case EventTypes.ProcessUpdatedEvent:
                 case EventTypes.ProcessClosedEvent:
                 case EventTypes.ProcessCompletedEvent:
+                case EventTypes.PatchOrAreaResEntityEditedEvent:
                     eventSns.GetActivityType().Should().Be(ActivityType.update);
                     break;
                 case EventTypes.ContactDetailDeletedEvent:
@@ -124,6 +125,9 @@ namespace ActivityListener.Tests.Factories
                 case EventTypes.CautionaryAlertCreatedEvent:
                 case EventTypes.CautionaryAlertEndedEvent:
                     eventSns.GetTargetType().Should().Be(TargetType.cautionaryAlert);
+                    break;
+                case EventTypes.PatchOrAreaResEntityEditedEvent:
+                    eventSns.GetTargetType().Should().Be(TargetType.patchesAndAreas);
                     break;
                 default:
                     {

--- a/ActivityListener/ActivityListener.csproj
+++ b/ActivityListener/ActivityListener.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
-    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.17.0" />
+    <PackageReference Include="Hackney.Shared.ActivityHistory" Version="0.18.0-feat-add-target-0001" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ActivityListener/EventTypes.cs
+++ b/ActivityListener/EventTypes.cs
@@ -37,5 +37,6 @@ namespace ActivityListener
 
         public const string CautionaryAlertCreatedEvent = "CautionaryAlertCreatedEvent";
         public const string CautionaryAlertEndedEvent = "CautionaryAlertEndedEvent";
+        public const string PatchOrAreaResEntityEditedEvent = "PatchOrAreaResEntityEditedEvent";
     }
 }

--- a/ActivityListener/Factories/EntityFactory.cs
+++ b/ActivityListener/Factories/EntityFactory.cs
@@ -33,6 +33,7 @@ namespace ActivityListener.Factories
                 case EventTypes.ProcessUpdatedEvent:
                 case EventTypes.ProcessClosedEvent:
                 case EventTypes.ProcessCompletedEvent:
+                case EventTypes.PatchOrAreaResEntityEditedEvent:
                     return ActivityType.update;
                 case EventTypes.ContactDetailDeletedEvent:
                 case EventTypes.PersonRemovedFromTenureEvent:
@@ -86,6 +87,8 @@ namespace ActivityListener.Factories
                 case EventTypes.CautionaryAlertCreatedEvent:
                 case EventTypes.CautionaryAlertEndedEvent:
                     return TargetType.cautionaryAlert;
+                case EventTypes.PatchOrAreaResEntityEditedEvent:
+                    return TargetType.patchesAndAreas;
 
                 default:
                     throw new ArgumentException($"Unknown event type: {eventSns.EventType}");

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -76,6 +76,10 @@ data "aws_ssm_parameter" "cautionary_alerts_sns_topic_arn" {
   name = "/sns-topic/staging/cautionary_alerts/arn"
 }
 
+data "aws_ssm_parameter" "patches_and_areas_sns_topic_arn" {
+  name = "/sns-topic/staging/patches-and-areas/arn"
+}
+
 resource "aws_sqs_queue" "activity_history_dead_letter_queue" {
   name                              = "activityhistorydeadletterqueue.fifo"
   fifo_queue                        = true
@@ -222,6 +226,18 @@ resource "aws_sqs_queue_policy" "activity_history_queue_policy" {
                       "aws:SourceArn": "${data.aws_ssm_parameter.cautionary_alerts_sns_topic_arn.value}"
                   }
               }
+          },
+          {
+              "Sid": "Eleventh",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "sqs:SendMessage",
+              "Resource": "${aws_sqs_queue.activity_history_queue.arn}",
+              "Condition": {
+                  "ArnEquals": {
+                      "aws:SourceArn": "${data.aws_ssm_parameter.patches_and_areas_sns_topic_arn.value}"
+                  }
+              }
           }
       ]
   }
@@ -299,6 +315,13 @@ resource "aws_sns_topic_subscription" "activity_history_queue_subscribe_to_contr
 
 resource "aws_sns_topic_subscription" "activity_history_queue_subscribe_to_cautionary_alerts_sns" {
   topic_arn            = data.aws_ssm_parameter.cautionary_alerts_sns_topic_arn.value
+  protocol             = "sqs"
+  endpoint             = aws_sqs_queue.activity_history_queue.arn
+  raw_message_delivery = true
+}
+
+resource "aws_sns_topic_subscription" "activity_history_queue_subscribe_to_patches_and_areas_sns" {
+  topic_arn            = data.aws_ssm_parameter.patches_and_areas_sns_topic_arn.value
   protocol             = "sqs"
   endpoint             = aws_sqs_queue.activity_history_queue.arn
   raw_message_delivery = true


### PR DESCRIPTION
Every time PatchesAndAreas ResponsibleEntity object is replaced it triggers the Activity listener which would then update the data in Activity History API