### PR TITLE
Check formatting misleading name fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,9 @@ workflows:
       jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
       - build-and-test:
           context:
             - api-nuget-token-context


### PR DESCRIPTION
The pipeline would run a job titled "deploy to staging and production" because the code formatting step didn't specify a branch