### PR TITLE
Fix dead letter queue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,19 +236,25 @@ workflows:
           context: api-nuget-token-context
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release
       - assume-role-development:
           context: api-assume-role-housing-development-context
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - release
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,18 +230,51 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  check:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              ignore: master
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
+          filters:
+            branches:
+              ignore: master
       - assume-role-development:
           context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore: master
+      - terraform-init-and-plan-development:
           requires:
-            - build-and-test
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              only: master
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
@@ -251,16 +284,12 @@ workflows:
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
-          filters:
-            branches:
-              only: master
+            - build-and-test
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
-          filters:
-            branches:
-              only: master
+          
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.env
+
 #Junk Files
 *.DS_Store
 [Tt]humbs.db

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.unitTests.runSettingsPath": "test.runsettings"
+}

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -12,7 +12,7 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk-11-jdk
+RUN apt-get update && apt-get install -y openjdk-17-jdk
 RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
 ENV PATH="$PATH:/root/.dotnet/tools"
 

--- a/ActivityListener.Tests/E2ETests/Steps/ProcessActivityEventSteps.cs
+++ b/ActivityListener.Tests/E2ETests/Steps/ProcessActivityEventSteps.cs
@@ -130,6 +130,7 @@ namespace ActivityListener.Tests.E2ETests.Steps
             var dbQuery = dbContext.QueryAsync<ActivityHistoryDB>(eventSns.EntityId);
             var resultsSet = await dbQuery.GetNextSetAsync().ConfigureAwait(false);
             resultsSet.Count.Should().Be(0);
+            _lastException.Should().BeNull();
         }
 
         private void VerifyDynamicDataObject(object expectedObj, object actualObj)

--- a/ActivityListener.Tests/E2ETests/Steps/ProcessActivityEventSteps.cs
+++ b/ActivityListener.Tests/E2ETests/Steps/ProcessActivityEventSteps.cs
@@ -125,6 +125,13 @@ namespace ActivityListener.Tests.E2ETests.Steps
             VerifyDynamicDataObject(expected.NewData, actual.NewData);
         }
 
+        public async Task ThenNoActivityHistoryRecordIsCreatedAsync(IDynamoDBContext dbContext, EntityEventSns eventSns)
+        {
+            var dbQuery = dbContext.QueryAsync<ActivityHistoryDB>(eventSns.EntityId);
+            var resultsSet = await dbQuery.GetNextSetAsync().ConfigureAwait(false);
+            resultsSet.Count.Should().Be(0);
+        }
+
         private void VerifyDynamicDataObject(object expectedObj, object actualObj)
         {
             JToken expected = JToken.Parse(System.Text.Json.JsonSerializer.Serialize(expectedObj, _jsonOptions));

--- a/ActivityListener.Tests/EventTypeHelper.cs
+++ b/ActivityListener.Tests/EventTypeHelper.cs
@@ -30,7 +30,11 @@ namespace ActivityListener.Tests
                 EventTypes.ProcessStartedAgainstPersonEvent,
                 EventTypes.CautionaryAlertCreatedEvent,
                 EventTypes.CautionaryAlertEndedEvent,
-                EventTypes.PatchOrAreaResEntityEditedEvent
+                EventTypes.PatchOrAreaResEntityEditedEvent,
+                EventTypes.NoteCreatedAgainstTenureEvent,
+                EventTypes.NoteCreatedAgainstPersonEvent,
+                EventTypes.NoteCreatedAgainstAssetEvent,
+                EventTypes.ContactDetailEditedEvent
             };
     }
 }

--- a/ActivityListener.Tests/Factories/EntityFactoryTest.cs
+++ b/ActivityListener.Tests/Factories/EntityFactoryTest.cs
@@ -89,6 +89,7 @@ namespace ActivityListener.Tests.Factories
             {
                 case EventTypes.AssetCreatedEvent:
                 case EventTypes.AssetUpdatedEvent:
+                case EventTypes.NoteCreatedAgainstAssetEvent:
                     eventSns.GetTargetType().Should().Be(TargetType.asset);
                     break;
                 case EventTypes.ContractCreatedEvent:
@@ -98,15 +99,18 @@ namespace ActivityListener.Tests.Factories
                 case EventTypes.PersonCreatedEvent:
                 case EventTypes.PersonUpdatedEvent:
                 case EventTypes.ProcessStartedAgainstPersonEvent:
+                case EventTypes.NoteCreatedAgainstPersonEvent:
                     eventSns.GetTargetType().Should().Be(TargetType.person);
                     break;
                 case EventTypes.ContactDetailAddedEvent:
                 case EventTypes.ContactDetailDeletedEvent:
+                case EventTypes.ContactDetailEditedEvent:
                     eventSns.GetTargetType().Should().Be(TargetType.contactDetails);
                     break;
                 case EventTypes.TenureCreatedEvent:
                 case EventTypes.TenureUpdatedEvent:
                 case EventTypes.ProcessStartedAgainstTenureEvent:
+                case EventTypes.NoteCreatedAgainstTenureEvent:
                     eventSns.GetTargetType().Should().Be(TargetType.tenure);
                     break;
                 case EventTypes.PersonAddedToTenureEvent:

--- a/ActivityListener.Tests/Factories/EntityFactoryTest.cs
+++ b/ActivityListener.Tests/Factories/EntityFactoryTest.cs
@@ -63,6 +63,12 @@ namespace ActivityListener.Tests.Factories
                 case EventTypes.CautionaryAlertEndedEvent:
                     eventSns.GetActivityType().Should().Be(ActivityType.end);
                     break;
+                case EventTypes.ContactDetailEditedEvent:
+                case EventTypes.NoteCreatedAgainstAssetEvent:
+                case EventTypes.NoteCreatedAgainstTenureEvent:
+                case EventTypes.NoteCreatedAgainstPersonEvent:
+                    eventSns.GetActivityType().Should().BeNull();
+                    break;
                 default:
                     {
                         Action act = () => eventSns.GetActivityType();

--- a/ActivityListener/EventTypes.cs
+++ b/ActivityListener/EventTypes.cs
@@ -15,6 +15,7 @@ namespace ActivityListener
         public const string PersonRemovedFromTenureEvent = "PersonRemovedFromTenureEvent";
 
         public const string ContactDetailAddedEvent = "ContactDetailAddedEvent";
+        public const string ContactDetailEditedEvent = "ContactDetailEditedEvent";
         public const string ContactDetailDeletedEvent = "ContactDetailDeletedEvent";
 
         public const string TenureCreatedEvent = "TenureCreatedEvent";
@@ -31,12 +32,16 @@ namespace ActivityListener
         public const string ProcessClosedEvent = "ProcessClosedEvent";
         public const string ProcessCompletedEvent = "ProcessCompletedEvent";
 
-        public const string NoteCreatedAgainstProcessEvent = "NoteCreatedAgainstProcessEvent";
         public const string ProcessStartedAgainstTenureEvent = "ProcessStartedAgainstTenureEvent";
         public const string ProcessStartedAgainstPersonEvent = "ProcessStartedAgainstPersonEvent";
 
         public const string CautionaryAlertCreatedEvent = "CautionaryAlertCreatedEvent";
         public const string CautionaryAlertEndedEvent = "CautionaryAlertEndedEvent";
         public const string PatchOrAreaResEntityEditedEvent = "PatchOrAreaResEntityEditedEvent";
+
+        public const string NoteCreatedAgainstProcessEvent = "NoteCreatedAgainstProcessEvent";
+        public const string NoteCreatedAgainstTenureEvent = "NoteCreatedAgainstTenureEvent";
+        public const string NoteCreatedAgainstPersonEvent = "NoteCreatedAgainstPersonEvent";
+        public const string NoteCreatedAgainstAssetEvent = "NoteCreatedAgainstAssetEvent";
     }
 }

--- a/ActivityListener/UseCase/MessageProcessor.cs
+++ b/ActivityListener/UseCase/MessageProcessor.cs
@@ -2,6 +2,7 @@ using ActivityListener.Boundary;
 using ActivityListener.Factories;
 using ActivityListener.Gateway.Interfaces;
 using ActivityListener.UseCase.Interfaces;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -10,10 +11,12 @@ namespace ActivityListener.UseCase
     public class MessageProcessor : IMessageProcessing
     {
         private readonly IDynamoDbGateway _dbGateway;
+        private readonly ILogger<MessageProcessor> _logger;
 
         public MessageProcessor(IDynamoDbGateway dbGateway)
         {
             _dbGateway = dbGateway;
+            _logger = new LoggerFactory().CreateLogger<MessageProcessor>();
         }
 
         public async Task ProcessMessageAsync(EntityEventSns message)
@@ -21,6 +24,12 @@ namespace ActivityListener.UseCase
             if (message is null) throw new ArgumentNullException(nameof(message));
 
             var domainObject = message.ToDomain();
+            if (domainObject is null)
+            {
+                _logger.LogWarning($"Will not process message of type: {message.EventType}");
+                return;
+            }
+
             await _dbGateway.SaveAsync(domainObject).ConfigureAwait(false);
         }
     }

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,13 @@
+<!-- For running tests locally -->
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+        <DynamoDb_LocalMode>true</DynamoDb_LocalMode>
+        <DynamoDb_LocalServiceUrl>http://localhost:8000</DynamoDb_LocalServiceUrl>
+        <AWS_REGION>eu-west-2</AWS_REGION>
+        <AWS_ACCESS_KEY_ID>local</AWS_ACCESS_KEY_ID>
+        <AWS_SECRET_ACCESS_KEY>local</AWS_SECRET_ACCESS_KEY>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,4 +1,3 @@
-<!-- For running tests locally -->
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <RunConfiguration>


### PR DESCRIPTION
[HPT-567](https://hackney.atlassian.net/browse/HPT-567) Determine why there are dead letters appearing in the Activity history queue

The dead letters were appearing because there were a number of activity history events that this listener has not been handling. These event types are:

- ContactDetailEditedEvent
- NoteCreatedAgainstAssetEvent
- NoteCreatedAgainstTenureEvent
- NoteCreatedAgainstPersonEvent

Currently when these events are received the listener throws an `ArgumentException` because it cannot match them to any specified events in the `EventFactory.cs` - this is a lambda failure which ultimately leads the events to the dead letter queue.

To keep things working as they are now but also clear the dead letter queue, this PR makes these events log a `Will not process message of type:` warning message and not take further action. It's assumed that there's not a pressing business need to properly handle these events as they have been failing for months.


[HPT-567]: https://hackney.atlassian.net/browse/HPT-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ