### PR TITLE
Complete Sonar Cloud configuration setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
-  sonarcloud: sonarsource/sonarcloud@1.1.1
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
           command: |
             mkdir coverage
             docker cp $(docker ps -aqf "name=activity-listener-test"):/app/coverage ./
-            sed -i " s|/app/|$(pwd)/|g" coverage/*/coverage.opencover.xml
+            sed -i "s|/app/|$(pwd)/|g" coverage/*/coverage.opencover.xml
       - sonarcloud/scan
   assume-role-development:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@1.1.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ jobs:
       - run:
           name: Run tests
           command: docker-compose run activity-listener-test
+      - sonarcloud/scan
   assume-role-development:
     executor: docker-python
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,12 @@ jobs:
       - run:
           name: Run tests
           command: docker-compose run activity-listener-test
+      - run:
+          name: Report
+          command: |
+            mkdir coverage
+            docker cp $(docker ps -aqf "name=activity-listener-test"):/app/coverage ./
+            sed -i " s|/app/|$(pwd)/|g" coverage/*/coverage.opencover.xml
       - sonarcloud/scan
   assume-role-development:
     executor: docker-python

--- a/ActivityListener.Tests/ActivityListener.Tests.csproj
+++ b/ActivityListener.Tests/ActivityListener.Tests.csproj
@@ -18,6 +18,10 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -16,8 +16,7 @@ COPY ./ActivityListener/ActivityListener.csproj ./ActivityListener/
 COPY ./ActivityListener.Tests/ActivityListener.Tests.csproj ./ActivityListener.Tests/
 COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./ActivityListener/ActivityListener.csproj
-RUN dotnet restore ./ActivityListener.Tests/ActivityListener.Tests.csproj
+RUN dotnet restore
 
 COPY . .
 

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -24,4 +24,4 @@ COPY . .
 RUN dotnet build -c Release -o out ActivityListener/ActivityListener.csproj
 RUN dotnet build -c debug -o out ActivityListener.Tests/ActivityListener.Tests.csproj
 
-CMD dotnet test --collect "XPlat Code Coverage;Format=opencover" --results-directory ./coverage
+ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -2,22 +2,14 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
-
 ENV DynamoDb_LocalMode='true'
+
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
-ARG SONAR_TOKEN
-ENV SONAR_TOKEN=$SONAR_TOKEN
-
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk-17-jdk
-RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
 ENV PATH="$PATH:/root/.dotnet/tools"
-
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_activity-history-listener" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
-
 
 # Copy csproj and restore as distinct layers
 COPY ./ActivityListener.sln ./
@@ -35,4 +27,3 @@ RUN dotnet build -c Release -o out ActivityListener/ActivityListener.csproj
 RUN dotnet build -c debug -o out ActivityListener.Tests/ActivityListener.Tests.csproj
 
 CMD dotnet test
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -26,4 +26,4 @@ COPY . .
 RUN dotnet build -c Release -o out ActivityListener/ActivityListener.csproj
 RUN dotnet build -c debug -o out ActivityListener.Tests/ActivityListener.Tests.csproj
 
-CMD dotnet test
+CMD dotnet test --collect "XPlat Code Coverage;Format=opencover" --results-directory ./coverage

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -20,7 +20,6 @@ RUN dotnet restore
 
 COPY . .
 
-RUN dotnet build -c Release -o out ActivityListener/ActivityListener.csproj
 RUN dotnet build -c debug -o out ActivityListener.Tests/ActivityListener.Tests.csproj
 
 ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -1,6 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0
 
-# disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 ENV DynamoDb_LocalMode='true'
 
@@ -20,7 +19,6 @@ COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 RUN dotnet restore ./ActivityListener/ActivityListener.csproj
 RUN dotnet restore ./ActivityListener.Tests/ActivityListener.Tests.csproj
 
-# Copy everything else and build
 COPY . .
 
 RUN dotnet build -c Release -o out ActivityListener/ActivityListener.csproj

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,12 +1,16 @@
+# Project / organisation
 sonar.projectKey=LBHackney-IT_activity-history-listener
 sonar.organization=lbhackney-it
 
-# This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=activity-history-listener
-#sonar.projectVersion=1.0
+# Service provider
+sonar.host.url=https://sonarcloud.io
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
+# Coverage options, exclude js/ts/css because it expects possibility of C# UI frameworks
+sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+sonar.dotnet.excludeTestProjects=true
+sonar.exclusions="**/*.js, **/*.ts, **/*.css"
+sonar.language=cs
 
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8 
+# Misc.
+sonar.sourceEncoding=UTF-8 
+sonar.verbose=true


### PR DESCRIPTION
# What:
 - Move the sonar can to be done within the CCI pipeline's container.
 - Use the CCI sonarcloud orb to do the scanning & results upload.
 - Combine static code analysis with tests code coverage.
 - Fix SonarCloud's reported Dockerfile code maintainability warnings.

# Why:
 - The pipeline was occasionally showing a red "X" failure due to Sonar Scan being flaky in regards to when it cares about the missing tests coverage and when not. This PR attempts to make the SonarCloud detect & receive the code coverage.

# Notes:
 - No code coverage is being detected now, because no code has changed. Seems like SonarCloud is more so interested in code coverage on "new code" or "changed code".
 - Based on the test done on a dummy feature branch, it would appear that this setup is picking code coverage just fine.

| Picking up code coverage on dummy changes | Lines coverage shown |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/81ef13ba-4c6f-43f0-b8a3-5ab011eb5960) | ![image](https://github.com/user-attachments/assets/8cdac65b-69a1-463b-b2e1-74d588d66f1a) |
