### PR TITLE
Upgrade pipeline's Serverless Framework to v4. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@2.0.0
+  node: circleci/node@6.3.0
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ commands:
       - node/install
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless@^3
+          command: npm i -g serverless
       - run:
           name: Build lambda
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
       - run:
           name: Install serverless CLI
           command: npm i -g serverless@^3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,9 @@ workflows:
             - terraform-compliance-development
             - build-and-test
       - deploy-to-development:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - terraform-apply-development
           
@@ -338,7 +340,9 @@ workflows:
             branches:
               only: release
       - deploy-to-staging:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - terraform-apply-staging
           filters:
@@ -382,7 +386,9 @@ workflows:
             branches:
               only: release
       - deploy-to-production:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - permit-production-release
           filters:


### PR DESCRIPTION
# What:
 - Upgrade & configure pipeline's Serverless Framework to version 4.
 - Update Node.js from the deprecated v14 to v22.

# Why:
 - Pipeline is experiencing cryptic failures whilst doing the serverless deploy step.

# Notes:
 - This listener does not have any plugins configured, so the Serverless 4 upgrade is simpler than usual.