### PR TITLE
Add Terraform preview to the feature branch workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check:
+  feature:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -264,7 +264,7 @@ workflows:
           requires:
             - terraform-init-and-plan-development
 
-  check-and-deploy-development:
+  development:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -298,7 +298,7 @@ workflows:
           requires:
             - terraform-apply-development
           
-  check-and-deploy-staging-and-production:
+  staging-and-production:
       jobs:
       - check-code-formatting:
           context: api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-preview:
+    description: "Gives a preview for Terraform configuration changes."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   terraform-apply:
     description: "Runs Terraform Apply"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,9 +290,12 @@ workflows:
       - preview-development-terraform:
           requires:
             - assume-role-development
-      - terraform-compliance-development:
+      - terraform-init-and-plan-development:
           requires:
             - preview-development-terraform
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,9 +280,8 @@ workflows:
               only: master
       - assume-role-development:
           context: api-assume-role-housing-development-context
-          filters:
-            branches:
-              only: master
+          requires:
+            - build-and-test
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
@@ -292,7 +291,6 @@ workflows:
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
-            - build-and-test
       - deploy-to-development:
           context:
             - api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,12 +287,32 @@ workflows:
               ignore:
                 - master
                 - release
-      - terraform-init-and-plan-development:
+      - preview-development-terraform:
           requires:
             - assume-role-development
       - terraform-compliance-development:
           requires:
-            - terraform-init-and-plan-development
+            - preview-development-terraform
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
 
   development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,21 @@ jobs:
     steps:
       - terraform-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:


### PR DESCRIPTION
# What:
 - Add Terraform preview steps to the feature branch workflow.

# Why:
 - To prevent accidental resource modification, downgrades, or destruction upon releasing new changes whilst having unforeseen Terraform drift.

# Notes:
 - Renamed workflows to have clearer names. The check and deploy name portion is implied from the environment name.