### PR TITLE
Upgrade the project from `dotnet6` to `dotnet8`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:1.1.9"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/ActivityListener.Tests/ActivityListener.Tests.csproj
+++ b/ActivityListener.Tests/ActivityListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/ActivityListener.Tests/Dockerfile
+++ b/ActivityListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 ENV DynamoDb_LocalMode='true'

--- a/ActivityListener/ActivityListener.csproj
+++ b/ActivityListener/ActivityListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 

--- a/ActivityListener/Dockerfile
+++ b/ActivityListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/ActivityListener/Properties/launchSettings.json
+++ b/ActivityListener/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment",
         "DynamoDb_LocalMode": "true",

--- a/ActivityListener/aws-lambda-tools-defaults.json
+++ b/ActivityListener/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "net6.0",
-  "function-runtime": "dotnet6",
+  "framework": "net8.0",
+  "function-runtime": "dotnet8",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "ActivityListener::ActivityListener.SqsFunction::FunctionHandler"

--- a/ActivityListener/build.cmd
+++ b/ActivityListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/activity-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/activity-listener.zip

--- a/ActivityListener/build.sh
+++ b/ActivityListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/activity-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/activity-listener.zip

--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -1,7 +1,7 @@
 service: activity-listener
 provider:
   name: aws
-  runtime: dotnet6
+  runtime: dotnet8
   memorySize: 2048
   tracing:
     lambda: true

--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -11,7 +11,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/net6.0/activity-listener.zip
+  artifact: ./bin/release/net8.0/activity-listener.zip
 
 functions:
   ActivityListener:


### PR DESCRIPTION
# What:
 - Update all the repository's configuration files to point to `dotnet8` sdk & runtime.

# Why:
 - Part of the wider `dotnet8` upgrades campaign that's meant to prevent us from getting blocked from deploying code to AWS Lambda (due to `dotnet6` support being dropped) as well as for us to be more responsive during disaster recovery.

# Notes:
 - This PR is for release to the `development` environment.