### PR TITLE
`[development]` Create an outgoing traffic security group for activity listener `[Pt1]`.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -38,7 +38,7 @@ terraform {
   }
 }
 
-data "aws_vpc" "development_vpc" {
+data "aws_vpc" "housing_development_vpc" {
   tags = {
     Name = "housing-dev"
   }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -44,6 +44,27 @@ data "aws_vpc" "development_vpc" {
   }
 }
 
+resource "aws_security_group" "activity_listener_sg" {
+  vpc_id = data.aws_vpc.housing_development_vpc.id
+  name_prefix = "activity_listener_outgoing_traffic"
+  description = "SG used to hook activity listener lambda into VPC. No incoming traffic allowed, all outgoing traffic allowed."
+
+  egress {
+    description = "allow outbound traffic"
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  
+  # No ingress - listener does not listen to incoming traffic
+  
+  tags = {
+    Name = "activity_listener-${var.environment_name}"
+  }
+}
+
 data "aws_ssm_parameter" "asset_sns_topic_arn" {
   name = "/sns-topic/development/asset/arn"
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -38,6 +38,11 @@ terraform {
   }
 }
 
+data "aws_vpc" "development_vpc" {
+  tags = {
+    Name = "housing-dev"
+  }
+}
 
 data "aws_ssm_parameter" "asset_sns_topic_arn" {
   name = "/sns-topic/development/asset/arn"


### PR DESCRIPTION
# What:
 - Add an outgoing traffic security group for activity listener within `development` environment.

# Why:
 - For one AWS suggests all lambdas to be attached to VPC due to security reasons.
 - Another thing is that serverless pipeline gives an error that it cannot attach lambda to the specified VPC. Essentially the configuration within serverless file is incomplete. So this PR creates a security group, that can be later attached to the lambda to get rid of this error.
 
 | ![image](https://github.com/user-attachments/assets/414e805c-d0ec-4dd9-9ec1-b97a1bb354f7) |
| --- |
| **Error that shows up during serverless deployment** |

# Notes:
 - Setting outgoing traffic only as listener is not expecting any requests (triggered from SQS), so doesn't need incoming traffic + needs outgoing traffic to reach DynamoDB service sitting on AWS.
 - This whole PR is test of whether attaching listener lambda to VPC will not cause any unforeseen issues. Hence, only the `development` environment changes are made.
 - This PR is just for creating the group, once it's id is known, a subsequent PR will be made to actually make lambda use the created group.