### PR TITLE
`[development]` Attach outgoing traffic security group to a listener lambda `[Pt2]`.

### DIFF
--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -115,6 +115,8 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-0dd956af4deb3df1e
       subnetIds:
         - subnet-0deabb5d8fb9c3446
         - subnet-000b89c249f12a8ad


### PR DESCRIPTION
# What:
 - Attach the outgoing-traffic-only security group to activity listener lambda.

# Why:
 - To fix the Serverless Framework error about missing security group within `provider.vpc` so that lambda would get attached to be inside the VPC for an increased security.

# Notes:
 - This PR continues on PR #95 .
 - When Lambda is attached to VPC, in the background one _(or more, depending on configured Lambda instances count)_ network interface is created. Such network interfaces have a specific private IP address depending on the subnet provided for the Lambda to get attached to. Security groups are mandatory for all network interfaces. So the Serverless Framework error likely comes from that it's specifying the VPC and subnets that Lambda should be attached to, but not a security group.
 - This PR will be released to `development` environment to test the impact of attaching a listener lambda to a VPC.