### PR TITLE
`[development]` Correct `housing-development` environment VPC ids `[Pt3]`.

### DIFF
--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -118,8 +118,9 @@ custom:
       securityGroupIds:
         - sg-0dd956af4deb3df1e
       subnetIds:
-        - subnet-0deabb5d8fb9c3446
-        - subnet-000b89c249f12a8ad
+        - subnet-0140d06fb84fdb547
+        - subnet-05ce390ba88c42bfd
+
     staging:
       subnetIds:
         - subnet-06d3de1bd9181b0d7


### PR DESCRIPTION
# What:
 - Correct the `housing-development` private subnet ids.

# Why:
 - The previously specified ones are non-existent.

# Notes:
 - This wasn't marked as a problem before because due to an issue mentioned on the PR #96 , serverless never got to the point where it attempted to find these VPC subnets.
 - This PR continues PR #96 .