### PR TITLE
`[staging/production]` Add missing security group ids and replace non-existing subnet ids `[Pt2]`.

### DIFF
--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -127,5 +127,5 @@ custom:
         - subnet-0743d86e9b362fa38
     production:
       subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
+        - subnet-0beb266003a56ca82
+        - subnet-06a697d86a9b6ed01

--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -123,8 +123,8 @@ custom:
 
     staging:
       subnetIds:
-        - subnet-06d3de1bd9181b0d7
-        - subnet-0ed7d7713d1127656
+        - subnet-0ea0020a44b98a2ca
+        - subnet-0743d86e9b362fa38
     production:
       subnetIds:
         - subnet-01d3657f97a243261

--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -120,8 +120,9 @@ custom:
       subnetIds:
         - subnet-0140d06fb84fdb547
         - subnet-05ce390ba88c42bfd
-
     staging:
+      securityGroupIds:
+        - sg-01f4442b04bfce797
       subnetIds:
         - subnet-0ea0020a44b98a2ca
         - subnet-0743d86e9b362fa38

--- a/ActivityListener/serverless.yml
+++ b/ActivityListener/serverless.yml
@@ -127,6 +127,8 @@ custom:
         - subnet-0ea0020a44b98a2ca
         - subnet-0743d86e9b362fa38
     production:
+      securityGroupIds:
+        - sg-08d4c465b11ce3349
       subnetIds:
         - subnet-0beb266003a56ca82
         - subnet-06a697d86a9b6ed01


### PR DESCRIPTION
# What: 
 - Update `serverless.yml` non-existent VPC subnet ids with the `housing-staging` and `housing-production` private ones.
 - Update `serverless.yml` to include missing VPC security groups to be applied to activity listener.

# Why:
 - To resolve the AWS induced serverless framework pipeline error that requires for a security group to be specified to attach the listener lambda to be run within the VPC for security reasons.
 - The subnet ids being non-existent wasn't picked up before, because serverless deployment has never reach a point where it would attempt to attach lambda to the VPC because of the missing inputs _(read more PR #97)_

# Notes:
 - This PR is a continuation of PR #100.